### PR TITLE
expose {fps} and {isHD} of recording

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -453,3 +453,7 @@ Version 1.2.8 (kamel5)
 
 - fixed some look sequence reports
 - Updated Makefile
+
+Version 1.2.8+ (pbiering)
+
+- expose {fps} and from 'info' retrieved {isHD} to recordings

--- a/coreengine/definitions.h
+++ b/coreengine/definitions.h
@@ -1159,6 +1159,8 @@ enum class eLeMenuRecordingsIT {
     hasposter,
     posterwidth,
     posterheight,
+    framesPerSecond,
+    isHD,
     count
 };
 
@@ -1202,6 +1204,8 @@ enum class eCeMenuRecordingsIT {
     hasposter,
     posterwidth,
     posterheight,
+    framesPerSecond,
+    isHD,
     count
 };
 
@@ -1312,6 +1316,8 @@ enum class eDmDetailedHeaderRecIT {
     durationeventhours,
     recimgavailable,
     recchannelnumber,
+    framesPerSecond,
+    isHD,
     count
 };
 
@@ -1419,6 +1425,8 @@ enum class eDmDetailedRecIT {
     recimg1avaialble,
     recimg2avaialble,
     recimg3avaialble,
+    framesPerSecond,
+    isHD,
     count
 };
 

--- a/coreengine/listelements.c
+++ b/coreengine/listelements.c
@@ -1710,6 +1710,8 @@ void cLeMenuRecordings::SetTokenContainer(void) {
     tokenContainer->DefineIntToken("{hasposter}", (int)eLeMenuRecordingsIT::hasposter);
     tokenContainer->DefineIntToken("{posterwidth}", (int)eLeMenuRecordingsIT::posterwidth);
     tokenContainer->DefineIntToken("{posterheight}", (int)eLeMenuRecordingsIT::posterheight);
+    tokenContainer->DefineIntToken("{fps}", (int)eLeMenuRecordingsIT::framesPerSecond);
+    tokenContainer->DefineIntToken("{isHD}", (int)eLeMenuRecordingsIT::isHD);
     InheritTokenContainer();
 }
 
@@ -1837,6 +1839,8 @@ bool cLeMenuRecordings::Parse(bool forced) {
 
     tokenContainer->AddStringToken((int)eLeMenuRecordingsST::shorttext, info->ShortText());
     tokenContainer->AddStringToken((int)eLeMenuRecordingsST::description, info->Description());
+    tokenContainer->AddIntToken((int)eLeMenuRecordingsIT::framesPerSecond, info->FramesPerSecond());
+    tokenContainer->AddIntToken((int)eLeMenuRecordingsIT::isHD, RecordingIsHD(event)); // detect HD from 'info'
 
     SetScraperRecordingPoster(tokenContainer, usedRecording, true);
 

--- a/coreengine/listelements.c
+++ b/coreengine/listelements.c
@@ -1961,6 +1961,8 @@ void cCeMenuRecordings::SetTokenContainer(void) {
     tokenContainer->DefineIntToken("{hasposter}", (int)eCeMenuRecordingsIT::hasposter);
     tokenContainer->DefineIntToken("{posterwidth}", (int)eCeMenuRecordingsIT::posterwidth);
     tokenContainer->DefineIntToken("{posterheight}", (int)eCeMenuRecordingsIT::posterheight);
+    tokenContainer->DefineIntToken("{fps}", (int)eCeMenuRecordingsIT::framesPerSecond);
+    tokenContainer->DefineIntToken("{isHD}", (int)eCeMenuRecordingsIT::isHD);
     InheritTokenContainer();
 }
 
@@ -2095,6 +2097,8 @@ bool cCeMenuRecordings::Parse(bool forced) {
 
     tokenContainer->AddStringToken((int)eCeMenuRecordingsST::shorttext, info->ShortText());
     tokenContainer->AddStringToken((int)eCeMenuRecordingsST::description, info->Description());
+    tokenContainer->AddIntToken((int)eCeMenuRecordingsIT::framesPerSecond, info->FramesPerSecond());
+    tokenContainer->AddIntToken((int)eCeMenuRecordingsIT::isHD, RecordingIsHD(event)); // detect HD from 'info'
 
     SetScraperRecordingPoster(tokenContainer, usedRecording, false);
 

--- a/coreengine/viewdetail.c
+++ b/coreengine/viewdetail.c
@@ -609,6 +609,8 @@ void cViewDetailRec::SetTokenContainer(void) {
     tokenContainer->DefineIntToken("{recimg1avaialble}", (int)eDmDetailedRecIT::recimg1avaialble);
     tokenContainer->DefineIntToken("{recimg2avaialble}", (int)eDmDetailedRecIT::recimg2avaialble);
     tokenContainer->DefineIntToken("{recimg3avaialble}", (int)eDmDetailedRecIT::recimg3avaialble);
+    tokenContainer->DefineIntToken("{fps}", (int)eDmDetailedRecIT::framesPerSecond);
+    tokenContainer->DefineIntToken("{isHD}", (int)eDmDetailedRecIT::isHD);
     tokenContainer->DefineIntToken("{ismovie}", (int)eScraperIT::ismovie);
     tokenContainer->DefineIntToken("{moviebudget}", (int)eScraperIT::moviebudget);
     tokenContainer->DefineIntToken("{movierevenue}", (int)eScraperIT::movierevenue);
@@ -672,6 +674,7 @@ bool cViewDetailRec::Parse(bool forced) {
         tokenContainer->AddStringToken((int)eDmDetailedRecST::epgname, info->Title());
         tokenContainer->AddStringToken((int)eDmDetailedRecST::shorttext, info->ShortText());
         tokenContainer->AddStringToken((int)eDmDetailedRecST::description, info->Description());
+        tokenContainer->AddIntToken((int)eDmDetailedRecIT::framesPerSecond, info->FramesPerSecond());
         const cEvent *event = info->GetEvent();
         if (event) {
             cString recDate = event->GetDateString();
@@ -697,6 +700,7 @@ bool cViewDetailRec::Parse(bool forced) {
             tokenContainer->AddIntToken((int)eDmDetailedRecIT::durationevent, duration);
             tokenContainer->AddIntToken((int)eDmDetailedRecIT::durationeventhours, duration / 60);
             tokenContainer->AddStringToken((int)eDmDetailedRecST::durationeventminutes, *cString::sprintf("%.2d", duration%60));
+            tokenContainer->AddIntToken((int)eDmDetailedRecIT::isHD, RecordingIsHD(event)); // detect HD from 'info'
         }
     }
     SetRecInfos();

--- a/coreengine/viewelement.c
+++ b/coreengine/viewelement.c
@@ -578,3 +578,36 @@ void cViewElement::StopAnimation(void) {
     if (fader)
         cView::RemoveAnimation(fader);
 }
+
+
+/******************************************************************
+ * helper function (did not find any other common place)
+ ******************************************************************/
+bool RecordingIsHD(const cEvent* event) {
+    // detect HD from 'info'
+    bool isHD = false;
+    cComponents *Components = (cComponents *)event->Components();
+    if (Components) {
+	// detect HD
+	// Stream: 1 = MPEG2-Video, 2 = MPEG2 Audio, 3 = Untertitel, 4 = AC3-Audio, 5 = H.264-Video, 6 = HEAAC-Audio
+	// Stream == Video: 01 = 05 = 4:3, 02 = 03 = 06 = 07 = 16:9, 04 = 08 = >16:9, 09 = 0D = HD 4:3, 0A = 0B = 0E = 0F = HD 16:9, 0C = 10 = HD >16:9
+
+	// get video stream component
+	tComponent *Component = Components->GetComponent(0, 5, 0);
+
+	if (Component) {
+	    switch (Component->type) {
+		case 0x09: // HD 4:3
+		case 0x0D: // HD 4:3
+		case 0x0A: // HD 16:9
+		case 0x0B: // HD 16:9
+		case 0x0E: // HD 16:9
+		case 0x0F: // HD 16:9
+		case 0x0C: // HD > 16:9
+		case 0x10: // HD > 16:9
+		    isHD = true;
+	    };
+	};
+    };
+    return isHD;
+};

--- a/coreengine/viewelement.c
+++ b/coreengine/viewelement.c
@@ -595,20 +595,20 @@ bool RecordingIsHD(const cEvent* event) {
 	tComponent *Component;
 	int type = -1;
 
-	// #1: MPEG2 (stream content: 1)
-	Component = Components->GetComponent(0, 1, 0);
+	// #1: HVEC (stream content: 9)
+	Component = Components->GetComponent(0, 9, 0);
 	if (Component) {
-	    type = Component->type;
+	    isHD = true; // HVEC is always HD, type 4 would be even UHD
 	} else {
 	    // #2: H.264 (stream content: 5)
 	    Component = Components->GetComponent(0, 5, 0);
 	    if (Component) {
 		type = Component->type;
 	    } else {
-		// #3: HVEC (stream content: 9)
-		Component = Components->GetComponent(0, 9, 0);
+		// #3: MPEG2 (stream content: 1)
+		Component = Components->GetComponent(0, 1, 0);
 		if (Component) {
-		    isHD = true; // HVEC is always HD, type 4 would be even UHD
+		    type = Component->type;
 		};
 	    };
 	};

--- a/coreengine/viewelement.h
+++ b/coreengine/viewelement.h
@@ -109,4 +109,10 @@ public:
     virtual void Debug(bool full = false);
 };
 
+
+/******************************************************************
+* helper function (did not find any other common place)
+******************************************************************/
+bool RecordingIsHD(const cEvent* event);
+
 #endif //__VIEWELEMENT_H

--- a/coreengine/viewelementsdisplaymenu.c
+++ b/coreengine/viewelementsdisplaymenu.c
@@ -1166,6 +1166,8 @@ void cVeDmDetailheaderRec::SetTokenContainer(void) {
     tokenContainer->DefineIntToken("{durationeventhours}", (int)eDmDetailedHeaderRecIT::durationeventhours);
     tokenContainer->DefineIntToken("{recimgavailable}", (int)eDmDetailedHeaderRecIT::recimgavailable);
     tokenContainer->DefineIntToken("{recchannelnumber}", (int)eDmDetailedHeaderRecIT::recchannelnumber);
+    tokenContainer->DefineIntToken("{fps}", (int)eDmDetailedHeaderRecIT::framesPerSecond);
+    tokenContainer->DefineIntToken("{isHD}", (int)eDmDetailedHeaderRecIT::isHD);
     InheritTokenContainer();
 }
 
@@ -1185,6 +1187,7 @@ bool cVeDmDetailheaderRec::Parse(bool forced) {
     if (info) {
         tokenContainer->AddStringToken((int)eDmDetailedHeaderRecST::epgname, info->Title());
         tokenContainer->AddStringToken((int)eDmDetailedHeaderRecST::shorttext, info->ShortText());
+        tokenContainer->AddIntToken((int)eDmDetailedHeaderRecIT::framesPerSecond, info->FramesPerSecond());
         const cEvent *event = info->GetEvent();
         if (event) {
             cString recDate = event->GetDateString();
@@ -1210,6 +1213,7 @@ bool cVeDmDetailheaderRec::Parse(bool forced) {
             tokenContainer->AddIntToken((int)eDmDetailedHeaderRecIT::durationevent, duration);
             tokenContainer->AddIntToken((int)eDmDetailedHeaderRecIT::durationeventhours, duration / 60);
             tokenContainer->AddStringToken((int)eDmDetailedHeaderRecST::durationeventminutes, *cString::sprintf("%.2d", duration%60));
+            tokenContainer->AddIntToken((int)eDmDetailedHeaderRecIT::isHD, RecordingIsHD(event)); // detect HD from 'info'
         }
 #if defined (APIVERSNUM) && (APIVERSNUM >= 20301)
         LOCK_CHANNELS_READ;

--- a/skinskeleton/xmlfiles/displaymenudetailrecording.xml
+++ b/skinskeleton/xmlfiles/displaymenudetailrecording.xml
@@ -29,6 +29,8 @@
     {recchannelname}          name of channel from which was recorded
     {recchannelid}            id of channel from which was recorded
     {recchannelnumber}        number of channel from which was recorded
+    {framesPerSecond}         frames per second (from EPG info)
+    {isHD}                    true if recording is HD (from EPG info)
     -->
     <detailheader>
     </detailheader>
@@ -49,6 +51,8 @@
     {durationeventhours}      event duration, full hours
     {durationeventminutes}    event duration, rest of minutes
     {cutted}                  true if recording is cutted
+    {framesPerSecond}         frames per second (from EPG info)
+    {isHD}                    true if recording is HD (from EPG info)
 
     {recordingsize}           size of recording (automatically in GB / MB)
     {recordingsizecutted}     size of cutted recording (automatically in GB / MB)

--- a/skinskeleton/xmlfiles/displaymenurecordings.xml
+++ b/skinskeleton/xmlfiles/displaymenurecordings.xml
@@ -33,6 +33,8 @@
         {posterwidth}           width of scraped poster
         {posterheight}          height of scraped poster
         {posterpath}            absolute path of scraped poster
+        {framesPerSecond}       frames per second (from EPG info)
+        {isHD}                  true if recording is HD (from EPG info)
         -->
         <listelement>
         </listelement>
@@ -72,6 +74,8 @@
         {bannerwidth}           width of scraped banner
         {bannerheight}          height of scraped banner
         {bannerpath}            absolute path of scraped banner        
+        {framesPerSecond}       frames per second (from EPG info)
+        {isHD}                  true if recording is HD (from EPG info)
         -->
         <currentelement delay="500" fadetime="0">
         </currentelement>


### PR DESCRIPTION
- like e.g. visible on old ReelBox recording menu this {isHD} can be used to display in recording list/details related  information/icon
- {fps} was added in addition for no costs, potentially useful also ;-)